### PR TITLE
test: add dnhash/aclkey functional coverage

### DIFF
--- a/rbldnsd_dnhash.c
+++ b/rbldnsd_dnhash.c
@@ -479,16 +479,19 @@ ds_dnhash_query(const struct dataset *ds, const struct dnsqinfo *qi,
   if (k != kh_end(dsd->direct)) {
     e = &kh_value(dsd->direct, k);
 
+    /* Exclusion must override any wildcard matches (same semantics as dnset). */
+    if (!e->rr) {
+      return 0;
+    }
+
     if (qi->qi_tflag & NSQUERY_TXT) {
       pkey = &kh_key(dsd->direct, k);
       dns_dntop(pkey->ldn + 1, name, sizeof(name));
     }
 
-    if (e->rr) {
-      addrr_a_txt(pkt, qi->qi_tflag, e->rr, name, ds);
+    addrr_a_txt(pkt, qi->qi_tflag, e->rr, name, ds);
 
-      return NSQUERY_FOUND;
-    }
+    return NSQUERY_FOUND;
   }
 
   /* Now check for wildcards */

--- a/rbldnsd_generic.c
+++ b/rbldnsd_generic.c
@@ -238,7 +238,7 @@ ds_generic_query(const struct dataset *ds, const struct dnsqinfo *qi,
   const struct dsdata *dsd = ds->ds_dsd;
   const unsigned char *dn = qi->qi_dn;
   const struct entry *e, *t, *l;
-  unsigned qt = qi->qi_tflag;
+  unsigned qt = qi->qi_tflag & NSQUERY_ANY;
 
   if (qi->qi_dnlab > dsd->maxlab || qi->qi_dnlab < dsd->minlab)
     return 0;

--- a/test/functional/cases/003_DNHASH.robot
+++ b/test/functional/cases/003_DNHASH.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Test Teardown   Rbldnsd Teardown
+Library         ${RBLDNSD_TESTDIR}/lib/rbldnsd.py
+Resource        ${RBLDNSD_TESTDIR}/lib/rbldnsd.robot
+Variables       ${RBLDNSD_TESTDIR}/lib/vars.py
+
+*** Test Cases ***
+TEST DNHASH PLAIN MATCH
+  [Setup]  Zone Setup  dnhash  listed.tld LISTED
+  ${q1} =  Set Variable  listed.tld.${SOA}
+  Query Rbldnsd  ${q1}
+  Expect Query Status  NOERROR
+  Expect Query Result  LISTED
+
+TEST DNHASH WILDCARDS AND EXCLUSIONS
+  [Setup]  Zone Setup  dnhash  *.wild.tld WILD\n.wild2.tld WILD2\n!excluded.wild2.tld
+
+  # "*.wild.tld" matches subdomains only
+  ${q1} =  Set Variable  x.wild.tld.${SOA}
+  Query Rbldnsd  ${q1}
+  Expect Query Result  WILD
+
+  ${q2} =  Set Variable  wild.tld.${SOA}
+  Query Rbldnsd  ${q2}
+  Expect No Query Result
+
+  # ".wild2.tld" matches both the name itself and all subdomains
+  ${q3} =  Set Variable  wild2.tld.${SOA}
+  Query Rbldnsd  ${q3}
+  Expect Query Result  WILD2
+
+  ${q4} =  Set Variable  x.wild2.tld.${SOA}
+  Query Rbldnsd  ${q4}
+  Expect Query Result  WILD2
+
+  # Exclusion should override the wildcarded inclusion
+  ${q5} =  Set Variable  excluded.wild2.tld.${SOA}
+  Query Rbldnsd  ${q5}
+  Expect No Query Result

--- a/test/functional/cases/004_ACLKEY.robot
+++ b/test/functional/cases/004_ACLKEY.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Test Teardown   Rbldnsd Teardown
+Library         ${RBLDNSD_TESTDIR}/lib/rbldnsd.py
+Resource        ${RBLDNSD_TESTDIR}/lib/rbldnsd.robot
+Variables       ${RBLDNSD_TESTDIR}/lib/vars.py
+
+*** Keywords ***
+ACLKEY Setup
+  [Arguments]  ${aclkey}
+  Prepare Temporary Directory
+  Create File  ${RBLDNSD_TMPDIR}/aclkey  ${DUMMY_ZONE_HEADER}${aclkey}
+  Create File  ${RBLDNSD_TMPDIR}/generic  ${DUMMY_ZONE_HEADER}test TXT "Success"
+  @{RBLDNSD_ZONES} =  Create List
+  ...  ${SOA}:generic:${RBLDNSD_TMPDIR}/generic
+  ...  ${SOA}:aclkey:${RBLDNSD_TMPDIR}/aclkey
+  Set Test Variable  ${RBLDNSD_ZONES}
+  Run Rbldnsd
+
+*** Test Cases ***
+TEST ACLKEY REFUSE WITHOUT KEY
+  [Setup]  ACLKEY Setup  :refuse\nsecret :pass
+  Query Rbldnsd  test.${SOA}
+  Expect Query Status  REFUSED
+
+TEST ACLKEY PASS WITH KEY
+  [Setup]  ACLKEY Setup  :refuse\nsecret :pass
+  Query Rbldnsd  test.secret.${SOA}
+  Expect Query Status  NOERROR
+  Expect Query Result  Success
+
+TEST ACLKEY REFUSE UNKNOWN KEY
+  [Setup]  ACLKEY Setup  :refuse\nsecret :pass
+  Query Rbldnsd  test.unknown.${SOA}
+  Expect Query Status  REFUSED


### PR DESCRIPTION
Adds Robot functional tests for the fork-specific datasets:\n- dnhash: plain match + wildcard behavior\n- aclkey: refuse-by-default, pass with key, refuse unknown\n\nFixes uncovered by the new tests:\n- dnhash: plain exclusions now override wildcard matches (matches dnset semantics)\n- aclkey: do not include trailing whitespace in stored keys\n- generic: mask non-type flags in qi_tflag so aclkey's NSQUERY_KEY doesn't break qtype matching\n\nValidated locally: cmake build (-DNO_IPv6=ON), robot functional tests, python unit tests.