### PR TITLE
Extract DNS hash to separate header with ARM64 support

### DIFF
--- a/dns_hash.h
+++ b/dns_hash.h
@@ -1,0 +1,153 @@
+/*
+ * dns_hash.h - Platform-optimized hash for DNS labels
+ *
+ * Copyright (C) 2019-2026 Vsevolod Stakhov
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA.
+ *
+ * Compile-time dispatch:
+ *   x86_64:  requires SSE4.2 (-msse4.2)
+ *   aarch64: requires ARMv8.1+ CRC (-march=armv8.1-a or -march=armv8-a+crc)
+ *   other:   FNV-1a fallback
+ */
+
+#ifndef DNS_HASH_H
+#define DNS_HASH_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Platform detection */
+#if defined(__SSE4_2__) && defined(__x86_64__)
+#  define DNS_HASH_CRC32_X86 1
+#  include <nmmintrin.h>
+#elif defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+#  define DNS_HASH_CRC32_ARM 1
+#  include <arm_acle.h>
+#endif
+
+/*
+ * Safe unaligned memory access helpers.
+ * DNS wire format data is not guaranteed to be aligned.
+ * Using __builtin_memcpy allows the compiler to optimize
+ * to native unaligned loads where supported.
+ */
+static inline uint64_t
+dns_hash_read64(const void *p)
+{
+	uint64_t v;
+	__builtin_memcpy(&v, p, sizeof(v));
+	return v;
+}
+
+static inline uint32_t
+dns_hash_read32(const void *p)
+{
+	uint32_t v;
+	__builtin_memcpy(&v, p, sizeof(v));
+	return v;
+}
+
+#if defined(DNS_HASH_CRC32_X86)
+
+/*
+ * x86_64 SSE4.2 CRC32-C implementation.
+ * Uses Castagnoli polynomial via hardware instruction.
+ */
+static inline uint32_t
+dns_label_hash(const unsigned char *data, size_t len)
+{
+	uint64_t crc = 0;
+
+	/* Process 8 bytes at a time */
+	while (len >= 8) {
+		crc = _mm_crc32_u64(crc, dns_hash_read64(data));
+		data += 8;
+		len -= 8;
+	}
+
+	/* Process 4 bytes if remaining */
+	if (len >= 4) {
+		crc = _mm_crc32_u32((uint32_t)crc, dns_hash_read32(data));
+		data += 4;
+		len -= 4;
+	}
+
+	/* Remaining 1-3 bytes */
+	while (len--) {
+		crc = _mm_crc32_u8((uint32_t)crc, *data++);
+	}
+
+	return (uint32_t)crc;
+}
+
+#elif defined(DNS_HASH_CRC32_ARM)
+
+/*
+ * ARM64 CRC32-C implementation via ACLE.
+ * Uses Castagnoli polynomial (same as Intel SSE4.2).
+ * Requires ARMv8.1-A or ARMv8-A with +crc extension.
+ */
+static inline uint32_t
+dns_label_hash(const unsigned char *data, size_t len)
+{
+	uint32_t crc = 0;
+
+	/* Process 8 bytes at a time */
+	while (len >= 8) {
+		crc = __crc32cd(crc, dns_hash_read64(data));
+		data += 8;
+		len -= 8;
+	}
+
+	/* Process 4 bytes if remaining */
+	if (len >= 4) {
+		crc = __crc32cw(crc, dns_hash_read32(data));
+		data += 4;
+		len -= 4;
+	}
+
+	/* Remaining 1-3 bytes */
+	while (len--) {
+		crc = __crc32cb(crc, *data++);
+	}
+
+	return crc;
+}
+
+#else
+
+/*
+ * FNV-1a fallback for non-x86_64/non-ARM64 platforms.
+ * Simple, well-tested hash with good distribution for short strings.
+ * Used extensively in DNS implementations.
+ */
+static inline uint32_t
+dns_label_hash(const unsigned char *data, size_t len)
+{
+	uint32_t hash = 2166136261u;  /* FNV offset basis */
+
+	while (len--) {
+		hash ^= *data++;
+		hash *= 16777619u;        /* FNV prime */
+	}
+
+	return hash;
+}
+
+#endif /* platform selection */
+
+#endif /* DNS_HASH_H */

--- a/rbldnsd_dnhash.c
+++ b/rbldnsd_dnhash.c
@@ -30,7 +30,7 @@
 #include <syslog.h>
 
 #include "khash.h"
-#include "t1ha/t1ha.h"
+#include "dns_hash.h"
 
 #include "rbldnsd.h"
 
@@ -44,243 +44,10 @@ struct entry {
   const struct kv_params *params;
 };
 
-#if defined(__SSE4_2__) && defined(__x86_64) && defined(__GNUC__)
-
-/* Machdep hash ported from openresty luajit: https://github.com/openresty/luajit2 */
-
-#include <smmintrin.h>
-#include <time.h> /* for time() */
-#include <sys/types.h>
-#include <unistd.h> /* for getpid() */
-
-static const uint64_t* cast_uint64p(const char* str)
-{
-  return (const uint64_t*)(void*)str;
-}
-
-static const uint32_t* cast_uint32p(const char* str)
-{
-  return (const uint32_t*)(void*)str;
-}
-
-/* hash string with len in [1, 4) */
-static inline uint32_t str_hash_1_4(const char* str, uint32_t len)
-{
-  uint32_t v = str[0];
-  v = (v << 8) | str[len >> 1];
-  v = (v << 8) | str[len - 1];
-  v = (v << 8) | len;
-  return _mm_crc32_u32(0, v);
-}
-
-/* hash string with len in [4, 16) */
-static inline uint32_t str_hash_4_16(const char* str, uint32_t len)
-{
-  uint64_t v1, v2, h;
-
-  if (len >= 8) {
-    v1 = *cast_uint64p(str);
-    v2 = *cast_uint64p(str + len - 8);
-  } else {
-    v1 = *cast_uint32p(str);
-    v2 = *cast_uint32p(str + len - 4);
-  }
-
-  h = _mm_crc32_u32(0, len);
-  h = _mm_crc32_u64(h, v1);
-  h = _mm_crc32_u64(h, v2);
-  return h;
-}
-
-/* hash string with length in [16, 128) */
-static inline uint32_t str_hash_16_128(const char* str, uint32_t len)
-{
-  uint64_t h1, h2;
-  uint32_t i;
-
-  h1 = _mm_crc32_u32(0, len);
-  h2 = 0;
-
-  for (i = 0; i < len - 16; i += 16) {
-    h1 += _mm_crc32_u64(h1, *cast_uint64p(str + i));
-    h2 += _mm_crc32_u64(h2, *cast_uint64p(str + i + 8));
-  };
-
-  h1 = _mm_crc32_u64(h1, *cast_uint64p(str + len - 16));
-  h2 = _mm_crc32_u64(h2, *cast_uint64p(str + len - 8));
-
-  return _mm_crc32_u32(h1, h2);
-}
-
-/* **************************************************************************
- *
- *  Following is code about hashing string with length >= 128
- *
- * **************************************************************************
- */
-static uint32_t random_pos[32][2];
-static const int8_t log2_tab[128] = { -1,0,1,1,2,2,2,2,3,3,3,3,3,3,3,3,4,4,
-  4,4,4,4,4,4,4,4,4,4,4,4,4,4,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
-  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,6,6,6,6,6,6,6,6,6,6,6,6,
-  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
-  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6 };
-
-static inline uint32_t log2_floor(uint32_t n)
-{
-  if (n <= 127) {
-    return log2_tab[n];
-  }
-
-  if ((n >> 8) <= 127) {
-    return log2_tab[n >> 8] + 8;
-  }
-
-  if ((n >> 16) <= 127) {
-    return log2_tab[n >> 16] + 16;
-  }
-
-  if ((n >> 24) <= 127) {
-    return log2_tab[n >> 24] + 24;
-  }
-
-  return 31;
-}
-
-#define POW2_MASK(n) ((1L << (n)) - 1)
-
-/* This function is to populate `random_pos` such that random_pos[i][*]
- * contains random value in the range of [2**i, 2**(i+1)).
- */
-static void x64_init_random(void)
-{
-  int i, seed, rml;
-
-  /* Calculate the ceil(log2(RAND_MAX)) */
-  rml = log2_floor(RAND_MAX);
-  if (RAND_MAX & (RAND_MAX - 1)) {
-    rml += 1;
-  }
-
-  /* Init seed */
-  seed = _mm_crc32_u32(0, getpid());
-  seed = _mm_crc32_u32(seed, time(NULL));
-  srandom(seed);
-
-  /* Now start to populate the random_pos[][]. */
-  for (i = 0; i < 3; i++) {
-    /* No need to provide random value for chunk smaller than 8 bytes */
-    random_pos[i][0] = random_pos[i][1] = 0;
-  }
-
-  for (; i < rml; i++) {
-    random_pos[i][0] = random() & POW2_MASK(i+1);
-    random_pos[i][1] = random() & POW2_MASK(i+1);
-  }
-
-  for (; i < 31; i++) {
-    int j;
-    for (j = 0; j < 2; j++) {
-      uint32_t v, scale;
-      scale = random_pos[i - rml][0];
-      if (scale == 0) {
-        scale = 1;
-      }
-      v = (random() * scale) & POW2_MASK(i+1);
-      random_pos[i][j] = v;
-    }
-  }
-}
-#undef POW2_MASK
-
-void __attribute__((constructor)) x64_init_random_constructor()
-{
-    x64_init_random();
-}
-
-/* Return a pre-computed random number in the range of [1**chunk_sz_order,
- * 1**(chunk_sz_order+1)). It is "unsafe" in the sense that the return value
- * may be greater than chunk-size; it is up to the caller to make sure
- * "chunk-base + return-value-of-this-func" has valid virtual address.
- */
-static inline uint32_t get_random_pos_unsafe(uint32_t chunk_sz_order,
-                                                 uint32_t idx)
-{
-  uint32_t pos = random_pos[chunk_sz_order][idx & 1];
-  return pos;
-}
-
-static inline uint32_t str_hash_128_above(const char* str,
-    uint32_t len)
-{
-  uint32_t chunk_num, chunk_sz, chunk_sz_log2, i, pos1, pos2;
-  uint64_t h1, h2, v;
-  const char* chunk_ptr;
-
-  chunk_num = 16;
-  chunk_sz = len / chunk_num;
-  chunk_sz_log2 = log2_floor(chunk_sz);
-
-  pos1 = get_random_pos_unsafe(chunk_sz_log2, 0);
-  pos2 = get_random_pos_unsafe(chunk_sz_log2, 1);
-
-  h1 = _mm_crc32_u32(0, len);
-  h2 = 0;
-
-  /* loop over 14 chunks, 2 chunks at a time */
-  for (i = 0, chunk_ptr = str; i < (chunk_num / 2 - 1);
-       chunk_ptr += chunk_sz, i++) {
-
-    v = *cast_uint64p(chunk_ptr + pos1);
-    h1 = _mm_crc32_u64(h1, v);
-
-    v = *cast_uint64p(chunk_ptr + chunk_sz + pos2);
-    h2 = _mm_crc32_u64(h2, v);
-  }
-
-  /* the last two chunks */
-  v = *cast_uint64p(chunk_ptr + pos1);
-  h1 = _mm_crc32_u64(h1, v);
-
-  v = *cast_uint64p(chunk_ptr + chunk_sz - 8 - pos2);
-  h2 = _mm_crc32_u64(h2, v);
-
-  /* process the trailing part */
-  h1 = _mm_crc32_u64(h1, *cast_uint64p(str));
-  h2 = _mm_crc32_u64(h2, *cast_uint64p(str + len - 8));
-
-  h1 = _mm_crc32_u32(h1, h2);
-  return h1;
-}
-
-/* NOTE: the "len" should not be zero */
-static inline uint32_t str_hash_machdep(const char* str, size_t len)
-{
-  if (len < 128) {
-    if (len >= 16) { /* [16, 128) */
-      return str_hash_16_128(str, len);
-    }
-
-    if (len >= 4) { /* [4, 16) */
-      return str_hash_4_16(str, len);
-    }
-
-    /* [0, 4) */
-    return str_hash_1_4(str, len);
-  }
-  /* [128, inf) */
-  return str_hash_128_above(str, len);
-}
-
-#define ARCH_STR_HASH(key, len) str_hash_machdep((key), (len))
-#else
-#define ARCH_STR_HASH(key, len)  t1ha2_atonce((key), (len), 0x0f0a13905c0bfd77ULL)
-#endif
-
-
 static inline int64_t
 key_hash_func(struct key k)
 {
-  return ARCH_STR_HASH(k.ldn, k.len);
+  return (int64_t)dns_label_hash(k.ldn, k.len);
 }
 
 static inline int
@@ -346,7 +113,7 @@ dnhash_bloom_mix(uint64_t x)
 static inline uint64_t
 dnhash_bloom_hash(const unsigned char *p, unsigned len)
 {
-  return (uint64_t)ARCH_STR_HASH((const char *)p, len);
+  return (uint64_t)dns_label_hash(p, len);
 }
 
 static inline void


### PR DESCRIPTION
## Summary

- Extract platform-specific hash functions from `rbldnsd_dnhash.c` to reusable `dns_hash.h` header
- Add ARM64 (aarch64) CRC32-C support via ACLE intrinsics
- Simplify implementation by removing unnecessary complexity for long strings (DNS max is 255 bytes)
- Replace t1ha dependency with inline FNV-1a fallback

## Changes

| Platform | Implementation | Intrinsics |
|----------|----------------|------------|
| x86_64 | CRC32-C via SSE4.2 | `_mm_crc32_u64/u8` |
| aarch64 | CRC32-C via ACLE | `__crc32cd/cb` |
| Other | FNV-1a | (portable) |

## Build Requirements

- **x86_64 packages**: Require SSE4.2 (`-msse4.2`)
- **aarch64 packages**: Require ARMv8.1+ or ARMv8-A+crc (`-march=armv8-a+crc`)
- **Source builds**: Will use FNV-1a fallback if hardware CRC unavailable

## Line count

```
Before: 832 lines (rbldnsd_dnhash.c with embedded hash)
After:  600 lines (rbldnsd_dnhash.c) + 153 lines (dns_hash.h)
Net:    ~80 lines removed, cleaner separation
```

## Test plan

- [ ] Build on x86_64 Linux with `-msse4.2`
- [ ] Build on ARM64 Linux with `-march=armv8-a+crc`
- [ ] Build without arch flags (fallback path)
- [ ] Run existing functional tests